### PR TITLE
Add Kafka Connect deployment #11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS=kafka-persisted kafka-inmemory kafka-statefulsets
+SUBDIRS=kafka-persisted kafka-inmemory kafka-statefulsets kafka-connect
 
 all: $(SUBDIRS)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This project provides a way to run an Apache Kafka cluster on Kubernetes and OpenShift with different types of deployment.
 
+<!-- TOC -->
+
+- [Kafka as a Service](#kafka-as-a-service)
+    - [Kafka persisted](#kafka-persisted)
+    - [Kafka in-memory](#kafka-in-memory)
+    - [Kafka Stateful Sets](#kafka-stateful-sets)
+        - [Deploying to OpenShift](#deploying-to-openshift)
+    - [Kafka Connect](#kafka-connect)
+        - [Deploying to OpenShift](#deploying-to-openshift-1)
+        - [Deploying to Kubernetes](#deploying-to-kubernetes)
+
+<!-- /TOC -->
+
 ## Kafka persisted
 
 With this deployment, a persistent volume is used in order to persist data for both Zookeeper server and Kafka brokers. At same time, with this deployment, when a Kafka instance
@@ -45,3 +58,19 @@ This deployment is available under the _kafka-statefulsets_ folder and provides 
 ### Deploying to OpenShift
 
 To conviniently deploy a StatefulSet to OpenShift a [Template is provided](kafka-statefulsets/resources/openshift-template.yaml), this could be used via `oc create -f kafka-statefulsets/resources/openshift-template.yaml` so it is present within your project. To create a whole Kafka StatefulSet use `oc new-app barnabas`.
+
+## Kafka Connect
+
+This deployment adds Kafka Connect cluster which can be used with the Kafka deployments above. It is implemented as deployment with a configurable number of workers. The default image currently contains only the Connectors which are part of Apache Kafka project - `FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect cluster is exposed internally withing the Kubernetes / OpenShift cluster as service `kafka-connect` on port `8083`.
+
+If you want to use other connectors, you can:
+* Mount a volume containing the plugins to path `/opt/kafka/plugins/`
+* Use the `enmasseproject/kafka-connect` image as Docker base image, add your connectors to the `/opt/kafka/plugins/` directory and use this new image instead of `enmasseproject/kafka-connect`
+
+### Deploying to OpenShift
+
+To conviniently deploy Kafka Connect to OpenShift a [Template is provided](kafka-connect/resources/openshift-template.yaml), this could be used via `oc create -f kafka-connect/resources/openshift-template.yaml` so it is present within your project. To create a whole Kafka StatefulSet use `oc new-app barnabas-connect`.
+
+### Deploying to Kubernetes
+
+To conviniently deploy Kafka Connect to Kubernetes use the provided yaml files with the Kafka Connect [deployment](kafka-connect/resources/kafka-connect.yaml) and [service](kafka-connect/resources/kafka-connect-service.yaml). This could be sone suing `kubectl apply -f kafka-connect/resources/kafka-connect.yaml` and `kubectl apply -f kafka-connect/resources/kafka-connect-service.yaml`.

--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -21,5 +21,7 @@ RUN mkdir $KAFKA_HOME \
 
 WORKDIR $KAFKA_HOME
 
+EXPOSE 8083
+
 # copy scripts for starting Kafka
 COPY ./scripts/ $KAFKA_HOME

--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -1,0 +1,25 @@
+FROM fedora:25
+
+RUN dnf -y install which java-1.8.0-openjdk libaio python gettext hostname iputils wget && dnf clean all -y
+
+# set Scala and Kafka version
+ENV SCALA_VERSION=2.11
+ENV KAFKA_VERSION=0.11.0.1
+# set Kafka home folder
+ENV KAFKA_HOME=/opt/kafka
+
+# Set from build args
+ARG version=latest
+ENV VERSION ${version}
+
+# downloading/extracting Apache Kafka
+RUN wget http://www.eu.apache.org/dist/kafka/$KAFKA_VERSION/kafka_$SCALA_VERSION-$KAFKA_VERSION.tgz
+
+RUN mkdir $KAFKA_HOME \
+    && tar xvfz kafka_$SCALA_VERSION-$KAFKA_VERSION.tgz -C $KAFKA_HOME --strip-components=1 \
+    && mkdir $KAFKA_HOME/plugins
+
+WORKDIR $KAFKA_HOME
+
+# copy scripts for starting Kafka
+COPY ./scripts/ $KAFKA_HOME

--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -23,5 +23,6 @@ WORKDIR $KAFKA_HOME
 
 EXPOSE 8083
 
-# copy scripts for starting Kafka
+# copy scripts for starting Kafka Connect
 COPY ./scripts/ $KAFKA_HOME
+ENTRYPOINT ["/opt/kafka/kafka_connect_run.sh"]

--- a/kafka-connect/Makefile
+++ b/kafka-connect/Makefile
@@ -1,0 +1,5 @@
+PROJECT_NAME=kafka-connect
+
+include ../Makefile.common
+
+.PHONY: build clean

--- a/kafka-connect/resources/kafka-connect-service.yaml
+++ b/kafka-connect/resources/kafka-connect-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-connect
+spec:
+  ports:
+    - port: 8083
+      name: rest-api
+      targetPort : 8083
+      protocol: TCP
+  selector:
+    name: kafka-connect

--- a/kafka-connect/resources/kafka-connect.yaml
+++ b/kafka-connect/resources/kafka-connect.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kafka-connect
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kafka-connect
+    spec:
+      containers:
+        - name: kafka-connect
+          image: enmasseproject/kafka-connect:latest
+          ports:
+            - name: rest-api
+              containerPort: 8083
+              protocol: TCP
+          command:
+            - /opt/kafka/kafka_connect_run.sh
+          env:
+            - name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
+              value: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
+            - name: KAFKA_CONNECT_GROUP_ID
+              value: "${KAFKA_CONNECT_GROUP_ID}"
+            - name: KAFKA_CONNECT_KEY_CONVERTER
+              value: "${KAFKA_CONNECT_KEY_CONVERTER}"
+            - name: KAFKA_CONNECT_VALUE_CONVERTER
+              value: "${KAFKA_CONNECT_VALUE_CONVERTER}"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: rest-api
+            initialDelaySeconds: 60

--- a/kafka-connect/resources/kafka-connect.yaml
+++ b/kafka-connect/resources/kafka-connect.yaml
@@ -16,8 +16,6 @@ spec:
             - name: rest-api
               containerPort: 8083
               protocol: TCP
-          command:
-            - /opt/kafka/kafka_connect_run.sh
           env:
             - name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
               value: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -67,8 +67,6 @@ objects:
               - name: rest-api
                 containerPort: 8083
                 protocol: TCP
-            command:
-              - /opt/kafka/kafka_connect_run.sh
             env:
               - name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
                 value: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: barnabas-connect
+parameters:
+- description: Specifies the number of Kafka Connect instances to be started by default.
+  displayName: Number of Kafka connect instances
+  name: INSTANCES
+  required: true
+  value: "1"
+- description: A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+  displayName: Kafka bootstrap servers
+  name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
+  required: true
+  value: kafka:9092
+- description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
+  displayName: Group ID
+  name: KAFKA_CONNECT_GROUP_ID
+  required: true
+  value: connect-cluster
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Key Converter
+  name: KAFKA_CONNECT_KEY_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Value Converter
+  name: KAFKA_CONNECT_VALUE_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Image repository name
+  displayName: Repository Name
+  name: IMAGE_REPO_NAME
+  value: enmasseproject 
+- description: Image name
+  displayName: Image Name
+  name: IMAGE_NAME
+  value: kafka-connect
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: kafka-connect
+  spec:
+    ports:
+      - port: 8083
+        name: rest-api
+        targetPort : 8083
+        protocol: TCP
+    selector:
+      name: kafka-connect
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: kafka-connect
+  spec:
+    replicas: ${INSTANCES}
+    template:
+      metadata:
+        labels:
+          name: kafka-connect
+      spec:
+        containers:
+          - name: kafka-connect
+            image: ${IMAGE_REPO_NAME}/${IMAGE_NAME}:latest
+            ports:
+              - name: rest-api
+                containerPort: 8083
+                protocol: TCP
+            command:
+              - /opt/kafka/kafka_connect_run.sh
+            env:
+              - name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
+                value: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
+              - name: KAFKA_CONNECT_GROUP_ID
+                value: "${KAFKA_CONNECT_GROUP_ID}"
+              - name: KAFKA_CONNECT_KEY_CONVERTER
+                value: "${KAFKA_CONNECT_KEY_CONVERTER}"
+              - name: KAFKA_CONNECT_VALUE_CONVERTER
+                value: "${KAFKA_CONNECT_VALUE_CONVERTER}"
+            livenessProbe:
+              httpGet:
+                path: /
+                port: rest-api
+              initialDelaySeconds: 60

--- a/kafka-connect/scripts/kafka_connect_run.sh
+++ b/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,39 +1,44 @@
 #!/bin/bash
+set -e
 
-if [ -z "$KAFKA_CONNECT_BOOTSTRAP_SERVERS" ]; then
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS="kafka:9092"
-fi
+# if command starts with an option, prepend qdrouterd
+if [ "$1" = 'bash' ]; then
+    exec "$@"
+else
+  if [ -z "$KAFKA_CONNECT_BOOTSTRAP_SERVERS" ]; then
+    KAFKA_CONNECT_BOOTSTRAP_SERVERS="kafka:9092"
+  fi
 
-if [ -z "$KAFKA_CONNECT_GROUP_ID" ]; then
-  KAFKA_CONNECT_GROUP_ID="connect-cluster"
-fi
+  if [ -z "$KAFKA_CONNECT_GROUP_ID" ]; then
+    KAFKA_CONNECT_GROUP_ID="connect-cluster"
+  fi
 
-if [ -z "$KAFKA_CONNECT_OFFSET_STORAGE_TOPIC" ]; then
-  KAFKA_CONNECT_OFFSET_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-offsets"
-fi
+  if [ -z "$KAFKA_CONNECT_OFFSET_STORAGE_TOPIC" ]; then
+    KAFKA_CONNECT_OFFSET_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-offsets"
+  fi
 
-if [ -z "$KAFKA_CONNECT_CONFIG_STORAGE_TOPIC" ]; then
-  KAFKA_CONNECT_CONFIG_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-configs"
-fi
+  if [ -z "$KAFKA_CONNECT_CONFIG_STORAGE_TOPIC" ]; then
+    KAFKA_CONNECT_CONFIG_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-configs"
+  fi
 
-if [ -z "$KAFKA_CONNECT_STATUS_STORAGE_TOPIC" ]; then
-  KAFKA_CONNECT_STATUS_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-status"
-fi
+  if [ -z "$KAFKA_CONNECT_STATUS_STORAGE_TOPIC" ]; then
+    KAFKA_CONNECT_STATUS_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-status"
+  fi
 
-if [ -z "$KAFKA_CONNECT_KEY_CONVERTER" ]; then
-  KAFKA_CONNECT_KEY_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
-fi
+  if [ -z "$KAFKA_CONNECT_KEY_CONVERTER" ]; then
+    KAFKA_CONNECT_KEY_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
+  fi
 
-if [ -z "$KAFKA_CONNECT_VALUE_CONVERTER" ]; then
-  KAFKA_CONNECT_VALUE_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
-fi
+  if [ -z "$KAFKA_CONNECT_VALUE_CONVERTER" ]; then
+    KAFKA_CONNECT_VALUE_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
+  fi
 
-if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
-  KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
-fi
+  if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
+    KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
+  fi
 
-# Write the config file
-cat > /tmp/barnabas-connect.properties <<EOF
+  # Write the config file
+  cat > /tmp/barnabas-connect.properties <<EOF
 bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
 group.id=${KAFKA_CONNECT_GROUP_ID}
 offset.storage.topic=${KAFKA_CONNECT_OFFSET_STORAGE_TOPIC}
@@ -50,9 +55,12 @@ internal.value.converter.schemas.enable=false
 plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
 EOF
 
-echo "Starting Kafka connect with configuration:"
-cat /tmp/barnabas-connect.properties
-echo ""
+  echo "Starting Kafka connect with configuration:"
+  cat /tmp/barnabas-connect.properties
+  echo ""
 
-# starting Kafka server with final configuration
-exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/barnabas-connect.properties
+  # starting Kafka server with final configuration
+  exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/barnabas-connect.properties
+fi
+
+

--- a/kafka-connect/scripts/kafka_connect_run.sh
+++ b/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# if command starts with an option, prepend qdrouterd
+# Start bash if requested. Otherwise start Kafka Connect
 if [ "$1" = 'bash' ]; then
     exec "$@"
 else
@@ -62,5 +62,3 @@ EOF
   # starting Kafka server with final configuration
   exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/barnabas-connect.properties
 fi
-
-

--- a/kafka-connect/scripts/kafka_connect_run.sh
+++ b/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+if [ -z "$KAFKA_CONNECT_BOOTSTRAP_SERVERS" ]; then
+  KAFKA_CONNECT_BOOTSTRAP_SERVERS="kafka:9092"
+fi
+
+if [ -z "$KAFKA_CONNECT_GROUP_ID" ]; then
+  KAFKA_CONNECT_GROUP_ID="connect-cluster"
+fi
+
+if [ -z "$KAFKA_CONNECT_OFFSET_STORAGE_TOPIC" ]; then
+  KAFKA_CONNECT_OFFSET_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-offsets"
+fi
+
+if [ -z "$KAFKA_CONNECT_CONFIG_STORAGE_TOPIC" ]; then
+  KAFKA_CONNECT_CONFIG_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-configs"
+fi
+
+if [ -z "$KAFKA_CONNECT_STATUS_STORAGE_TOPIC" ]; then
+  KAFKA_CONNECT_STATUS_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-status"
+fi
+
+if [ -z "$KAFKA_CONNECT_KEY_CONVERTER" ]; then
+  KAFKA_CONNECT_KEY_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
+fi
+
+if [ -z "$KAFKA_CONNECT_VALUE_CONVERTER" ]; then
+  KAFKA_CONNECT_VALUE_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
+fi
+
+if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
+  KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
+fi
+
+# Write the config file
+cat > /tmp/barnabas-connect.properties <<EOF
+bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
+group.id=${KAFKA_CONNECT_GROUP_ID}
+offset.storage.topic=${KAFKA_CONNECT_OFFSET_STORAGE_TOPIC}
+config.storage.topic=${KAFKA_CONNECT_CONFIG_STORAGE_TOPIC}
+status.storage.topic=${KAFKA_CONNECT_STATUS_STORAGE_TOPIC}
+key.converter=${KAFKA_CONNECT_KEY_CONVERTER}
+value.converter=${KAFKA_CONNECT_VALUE_CONVERTER}
+key.converter.schemas.enable=false
+value.converter.schemas.enable=false
+internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+internal.key.converter.schemas.enable=false
+internal.value.converter.schemas.enable=false
+plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
+EOF
+
+echo "Starting Kafka connect with configuration:"
+cat /tmp/barnabas-connect.properties
+echo ""
+
+# starting Kafka server with final configuration
+exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/barnabas-connect.properties


### PR DESCRIPTION
This PR adds support for Kafka Connect. Adding of custom connectors "on-demand" is not yet solved. It can be done using volumes or by using the image as a base image.