### PR TITLE
Remove KAFKA_VERSION and add parameters to configure image tags #19

### DIFF
--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -36,6 +36,10 @@ parameters:
   displayName: Image Name
   name: IMAGE_NAME
   value: kafka-connect
+- description: Image tag
+  displayName: Image tag
+  name: IMAGE_TAG
+  value: latest
 objects:
 - apiVersion: v1
   kind: Service
@@ -62,7 +66,7 @@ objects:
       spec:
         containers:
           - name: kafka-connect
-            image: ${IMAGE_REPO_NAME}/${IMAGE_NAME}:latest
+            image: ${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}
             ports:
               - name: rest-api
                 containerPort: 8083

--- a/kafka-connect/s2i/resources/openshift-template.yaml
+++ b/kafka-connect/s2i/resources/openshift-template.yaml
@@ -3,29 +3,29 @@ kind: Template
 metadata:
   name: barnabas-connect-s2i
 parameters:
-- description: Specifies the name of the Build which will be created by this template
-  displayName: Name of the Build
+- description: Name of the Build which will be created by this template
+  displayName: Build name
   name: BUILD_NAME
   required: true
   value: "kafka-connect"
-- description: Specifies the name of the new Kafka Connect Docker image which will be generated
-  displayName: Name of the newly generated Docker image
+- description: Name of the new Kafka Connect Docker image which will be generated
+  displayName: Target image name
   name: TARGET_IMAGE_NAME
   required: true
   value: "kafka-connect"
-- description: Specifies the tag of the new Kafka Connect Docker image which will be generated
-  displayName: Tag of the newly generated Docker image
+- description: Tag of the new Kafka Connect Docker image which will be generated
+  displayName: Target image tag
   name: TARGET_IMAGE_TAG
   value: latest
-- description: Image repository name of the source S2I Docker image
-  displayName: Repository Name of the S2I image
+- description: Image repository name of the S2I Docker image
+  displayName: S2I image repository
   name: S2I_IMAGE_REPO_NAME
   value: enmasseproject 
-- description: Name of the source S2I Docker image
-  displayName: Name of the S2I image
+- description: Name of the S2I Docker image
+  displayName: S2I image name
   name: S2I_IMAGE_NAME
   value: kafka-connect-s2i
-- description: S2I image tag
+- description: Tag of the S2I Docker image
   displayName: S2I image tag
   name: S2I_IMAGE_TAG
   value: latest

--- a/kafka-connect/s2i/resources/openshift-template.yaml
+++ b/kafka-connect/s2i/resources/openshift-template.yaml
@@ -13,6 +13,10 @@ parameters:
   name: TARGET_IMAGE_NAME
   required: true
   value: "kafka-connect"
+- description: Specifies the tag of the new Kafka Connect Docker image which will be generated
+  displayName: Tag of the newly generated Docker image
+  name: TARGET_IMAGE_TAG
+  value: latest
 - description: Image repository name of the source S2I Docker image
   displayName: Repository Name of the S2I image
   name: S2I_IMAGE_REPO_NAME
@@ -21,6 +25,10 @@ parameters:
   displayName: Name of the S2I image
   name: S2I_IMAGE_NAME
   value: kafka-connect-s2i
+- description: S2I image tag
+  displayName: S2I image tag
+  name: S2I_IMAGE_TAG
+  value: latest
 objects:
 - apiVersion: v1
   kind: ImageStream
@@ -54,7 +62,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ${TARGET_IMAGE_NAME}:latest
+        name: ${TARGET_IMAGE_NAME}:${TARGET_IMAGE_TAG}
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -65,7 +73,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: ${S2I_IMAGE_NAME}:latest
+          name: ${S2I_IMAGE_NAME}:${S2I_IMAGE_TAG}
       type: Source
     triggers:
     - type: ConfigChange

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -11,10 +11,18 @@ parameters:
   displayName: Kafka image Name
   name: KAFKA_IMAGE_NAME
   value: kafka-statefulsets
+- description: Kafka image tag
+  displayName: Kafka image tag
+  name: KAFKA_IMAGE_TAG
+  value: latest
 - description: Zookeeper image name
   displayName: Zookeeper image Name
   name: ZOOKEEPER_IMAGE_NAME
   value: zookeeper
+- description: Zookeeper image tag
+  displayName: Zookeeper image tag
+  name: ZOOKEEPER_IMAGE_TAG
+  value: latest
 objects:
 - apiVersion: v1
   kind: Service
@@ -93,7 +101,7 @@ objects:
       spec:
         containers:
         - name: kafka
-          image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:latest
+          image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 9092
@@ -129,7 +137,7 @@ objects:
       spec:
         containers:
         - name: zookeeper
-          image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:latest
+          image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 2181

--- a/kafka-statefulsets/resources/openshift-template.yaml
+++ b/kafka-statefulsets/resources/openshift-template.yaml
@@ -21,14 +21,18 @@ parameters:
   displayName: Kafka image Name
   name: KAFKA_IMAGE_NAME
   value: kafka-statefulsets
+- description: Kafka image tag
+  displayName: Kafka image tag
+  name: KAFKA_IMAGE_TAG
+  value: latest
 - description: Zookeeper image name
   displayName: Zookeeper image Name
   name: ZOOKEEPER_IMAGE_NAME
   value: zookeeper
-- description: Kafka Version
-  displayName: Kafka Version
-  name: KAFKA_VERSION
-  value: "0.11.0.0"
+- description: Zookeeper image tag
+  displayName: Zookeeper image tag
+  name: ZOOKEEPER_IMAGE_TAG
+  value: latest
 objects:
 - apiVersion: v1
   kind: Service
@@ -107,7 +111,7 @@ objects:
       spec:
         containers:
         - name: kafka
-          image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:latest
+          image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 9092
@@ -149,7 +153,7 @@ objects:
       spec:
         containers:
         - name: zookeeper
-          image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:latest
+          image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 2181


### PR DESCRIPTION
This PR address the issue #19. It:
* Removes the parameter KAFKA_VERSION which is not used
* Adds a new parameters to configure the docker image tags which will be used in the deployments