### PR TITLE
MINOR: Fix the awk command in kafka_run.sh

### DIFF
--- a/kafka-statefulsets/scripts/kafka_run.sh
+++ b/kafka-statefulsets/scripts/kafka_run.sh
@@ -6,7 +6,7 @@ export KAFKA_VOLUME="/var/lib/kafka/"
 export KAFKA_LOG_BASE_NAME="kafka-log"
 export KAFKA_APP_LOGS_BASE_NAME="logs"
 
-export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $2}')
+export KAFKA_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')
 echo "KAFKA_BROKER_ID=$KAFKA_BROKER_ID"
 
 # create data dir


### PR DESCRIPTION
`kafka_run.sh` is parsing the hostname using `awk` to get the statefulset index number out of it. The current command splits the hostname by `-` and takes the second segment as the ID. Tis works fine when the name is `kafka-0` or `kafka-1`. But doesn't work properly when the name would be `my-kafka-1`. Barnabas currently doesn't provide any support for changing the statefulset name, but it would be good to fix this anyway in case someone renames it in the YAML files.