### PR TITLE
Change the way Kafka brokers are configured so that they use DNS name as advertised host #50

### DIFF
--- a/kafka-inmemory/resources/kafka.yaml
+++ b/kafka-inmemory/resources/kafka.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: kafka
 spec:
-  serviceName: "kafka"
+  serviceName: "kafka-headless"
   # used 3 replicas in order to have alwayas majority for leader election
   replicas: 3
   template:

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -111,7 +111,7 @@ objects:
     selector:
       matchLabels:
         name: kafka
-    serviceName: kafka
+    serviceName: kafka-headless
     template:
       metadata:
         labels:

--- a/kafka-statefulsets/resources/kafka.yaml
+++ b/kafka-statefulsets/resources/kafka.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: kafka
 spec:
-  serviceName: "kafka"
+  serviceName: "kafka-headless"
   # used 3 replicas in order to have alwayas majority for leader election
   replicas: 3
   template:

--- a/kafka-statefulsets/resources/openshift-template.yaml
+++ b/kafka-statefulsets/resources/openshift-template.yaml
@@ -121,7 +121,7 @@ objects:
     selector:
       matchLabels:
         name: kafka
-    serviceName: kafka
+    serviceName: kafka-headless
     template:
       metadata:
         labels:

--- a/kafka-statefulsets/scripts/kafka_run.sh
+++ b/kafka-statefulsets/scripts/kafka_run.sh
@@ -20,6 +20,6 @@ echo "LOG_DIR=$LOG_DIR"
 # starting Kafka server with final configuration
 exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties \
 --override broker.id=$KAFKA_BROKER_ID \
---override advertised.host.name=$(hostname -I) \
+--override advertised.host.name=$(hostname -f) \
 --override zookeeper.connect=$ZOOKEEPER_SERVICE_HOST:$ZOOKEEPER_SERVICE_PORT \
 --override log.dirs=$KAFKA_LOG_DIRS


### PR DESCRIPTION
Apart from changing the `kafka_run.sh` script to use fully qualified hostname as the advertised hostname it was also needed to change the service name for the kafka deployments so that it matches name of the headless service which can take care of the pod hostname propagation in the DNS service.