### PR TITLE
Rollback to using IP address instead of DNS name from #50

### DIFF
--- a/kafka-statefulsets/scripts/kafka_run.sh
+++ b/kafka-statefulsets/scripts/kafka_run.sh
@@ -20,6 +20,6 @@ echo "LOG_DIR=$LOG_DIR"
 # starting Kafka server with final configuration
 exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties \
 --override broker.id=$KAFKA_BROKER_ID \
---override advertised.host.name=$(hostname -f) \
+--override advertised.host.name=$(hostname -I) \
 --override zookeeper.connect=$ZOOKEEPER_SERVICE_HOST:$ZOOKEEPER_SERVICE_PORT \
 --override log.dirs=$KAFKA_LOG_DIRS


### PR DESCRIPTION
It looks like the change to DNS hostnames caused some problems to users who are using Kafka from outside of OpenShift since the hostnames don't resolve outside of OpenShift. We should rollback this change and revisit it later when we have other ways how to make Kafka available outside of OpenShift.