### PR TITLE
Kafka Inmemory is using config dirs which do not need fsGroup unlike …

### DIFF
--- a/kafka-inmemory/resources/kafka.yaml
+++ b/kafka-inmemory/resources/kafka.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         name: kafka
     spec:
-      securityContext:
-        fsGroup: 1001
       containers:
         - name: kafka
           image: "enmasseproject/kafka-statefulsets:latest"

--- a/kafka-inmemory/resources/zookeeper.yaml
+++ b/kafka-inmemory/resources/zookeeper.yaml
@@ -10,8 +10,6 @@ spec:
       labels:
         name: zookeeper
     spec:
-      securityContext:
-        fsGroup: 1001
       containers:
         - name: zookeeper
           image: "enmasseproject/zookeeper:latest"


### PR DESCRIPTION
…real persistent volumes