### PR TITLE
Use the same field order for all port definitions in pods and services

### DIFF
--- a/kafka-connect/resources/kafka-connect-service.yaml
+++ b/kafka-connect/resources/kafka-connect-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: kafka-connect
 spec:
   ports:
-    - port: 8083
-      name: rest-api
-      targetPort : 8083
+    - name: rest-api
+      port: 8083
+      targetPort: 8083
       protocol: TCP
   selector:
     name: kafka-connect

--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -59,9 +59,9 @@ objects:
     name: kafka-connect
   spec:
     ports:
-      - port: 8083
-        name: rest-api
-        targetPort : 8083
+      - name: rest-api
+        port: 8083
+        targetPort: 8083
         protocol: TCP
     selector:
       name: kafka-connect

--- a/kafka-connect/s2i/resources/openshift-template.yaml
+++ b/kafka-connect/s2i/resources/openshift-template.yaml
@@ -127,9 +127,9 @@ objects:
     name: kafka-connect
   spec:
     ports:
-      - port: 8083
-        name: rest-api
-        targetPort : 8083
+      - name: rest-api
+        port: 8083
+        targetPort: 8083
         protocol: TCP
     selector:
       name: kafka-connect

--- a/kafka-inmemory/resources/kafka-headless-service.yaml
+++ b/kafka-inmemory/resources/kafka-headless-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: kafka-headless
 spec:
   ports:
-    - port: 9092
-      name: kafka
-      targetPort : 9092
+    - name: kafka
+      port: 9092
+      targetPort: 9092
       protocol: TCP
   selector:
     name: kafka

--- a/kafka-inmemory/resources/kafka-service.yaml
+++ b/kafka-inmemory/resources/kafka-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: kafka
 spec:
   ports:
-    - port: 9092
-      name: kafka
-      targetPort : 9092
+    - name: kafka
+      port: 9092
+      targetPort: 9092
       protocol: TCP
   selector:
     name: kafka

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -70,8 +70,8 @@ objects:
     ports:
     - name: kafka
       port: 9092
-      protocol: TCP
       targetPort: 9092
+      protocol: TCP
     selector:
       name: kafka
     type: ClusterIP
@@ -83,8 +83,8 @@ objects:
     ports:
     - name: kafka
       port: 9092
-      protocol: TCP
       targetPort: 9092
+      protocol: TCP
     selector:
       name: kafka
     type: ClusterIP
@@ -97,8 +97,8 @@ objects:
     ports:
     - name: clientport
       port: 2181
-      protocol: TCP
       targetPort: 2181
+      protocol: TCP
     selector:
       name: zookeeper
     type: ClusterIP
@@ -110,15 +110,15 @@ objects:
     ports:
     - name: clientport
       port: 2181
-      protocol: TCP
       targetPort: 2181
-    - port: 2888
-      name: clustering
-      targetPort : 2888
       protocol: TCP
-    - port: 3888
-      name: leaderelection
-      targetPort : 3888
+    - name: clustering
+      port: 2888
+      targetPort: 2888
+      protocol: TCP
+    - name: leaderelection
+      port: 3888
+      targetPort: 3888
       protocol: TCP
     selector:
       name: zookeeper
@@ -146,8 +146,8 @@ objects:
           image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
-          - containerPort: 9092
-            name: kafka
+          - name: kafka
+            containerPort: 9092
             protocol: TCP
           env:
           - name: KAFKA_DEFAULT_REPLICATION_FACTOR
@@ -201,14 +201,14 @@ objects:
           image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
-          - containerPort: 2181
-            name: clientport
+          - name: clientport
+            containerPort: 2181
             protocol: TCP
-          - containerPort: 2888
-            name: clustering
+          - name: clustering
+            containerPort: 2888
             protocol: TCP
-          - containerPort: 3888
-            name: leaderelection
+          - name: leaderelection
+            containerPort: 3888
             protocol: TCP
           env:
           - name: ZOOKEEPER_NODE_COUNT

--- a/kafka-inmemory/resources/zookeeper-headless-service.yaml
+++ b/kafka-inmemory/resources/zookeeper-headless-service.yaml
@@ -4,17 +4,17 @@ metadata:
   name: zookeeper-headless
 spec:
   ports:
-    - port: 2181
-      name: clientport
-      targetPort : 2181
+    - name: clientport
+      port: 2181
+      targetPort: 2181
       protocol: TCP
-    - port: 2888
-      name: clustering
-      targetPort : 2888
+    - name: clustering
+      port: 2888
+      targetPort: 2888
       protocol: TCP
-    - port: 3888
-      name: leaderelection
-      targetPort : 3888
+    - name: leaderelection
+      port: 3888
+      targetPort: 3888
       protocol: TCP
   selector:
     name: zookeeper

--- a/kafka-inmemory/resources/zookeeper-service.yaml
+++ b/kafka-inmemory/resources/zookeeper-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zookeeper
 spec:
   ports:
-    - port: 2181
-      name: clientport
-      targetPort : 2181
+    - name: clientport
+      port: 2181
+      targetPort: 2181
       protocol: TCP
   selector:
     name: zookeeper

--- a/kafka-inmemory/resources/zookeeper.yaml
+++ b/kafka-inmemory/resources/zookeeper.yaml
@@ -17,11 +17,11 @@ spec:
             - name: clientport
               containerPort: 2181
               protocol: TCP
-            - containerPort: 2888
-              name: clustering
+            - name: clustering
+              containerPort: 2888
               protocol: TCP
-            - containerPort: 3888
-              name: leaderelection
+            - name: leaderelection
+              containerPort: 3888
               protocol: TCP
           env:
             - name: ZOOKEEPER_NODE_COUNT

--- a/kafka-statefulsets/resources/kafka-headless-service.yaml
+++ b/kafka-statefulsets/resources/kafka-headless-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: kafka-headless
 spec:
   ports:
-    - port: 9092
-      name: kafka
-      targetPort : 9092
+    - name: kafka
+      port: 9092
+      targetPort: 9092
       protocol: TCP
   selector:
     name: kafka

--- a/kafka-statefulsets/resources/kafka-service.yaml
+++ b/kafka-statefulsets/resources/kafka-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: kafka
 spec:
   ports:
-    - port: 9092
-      name: kafka
-      targetPort : 9092
+    - name: kafka
+      port: 9092
+      targetPort: 9092
       protocol: TCP
   selector:
     name: kafka

--- a/kafka-statefulsets/resources/openshift-template.yaml
+++ b/kafka-statefulsets/resources/openshift-template.yaml
@@ -80,8 +80,8 @@ objects:
     ports:
     - name: kafka
       port: 9092
-      protocol: TCP
       targetPort: 9092
+      protocol: TCP
     selector:
       name: kafka
     type: ClusterIP
@@ -93,8 +93,8 @@ objects:
     ports:
     - name: kafka
       port: 9092
-      protocol: TCP
       targetPort: 9092
+      protocol: TCP
     selector:
       name: kafka
     type: ClusterIP
@@ -107,8 +107,8 @@ objects:
     ports:
     - name: clientport
       port: 2181
-      protocol: TCP
       targetPort: 2181
+      protocol: TCP
     selector:
       name: zookeeper
     type: ClusterIP
@@ -120,15 +120,15 @@ objects:
     ports:
     - name: clientport
       port: 2181
-      protocol: TCP
       targetPort: 2181
-    - port: 2888
-      name: clustering
-      targetPort : 2888
       protocol: TCP
-    - port: 3888
-      name: leaderelection
-      targetPort : 3888
+    - name: clustering
+      port: 2888
+      targetPort: 2888
+      protocol: TCP
+    - name: leaderelection
+      port: 3888
+      targetPort: 3888
       protocol: TCP
     selector:
       name: zookeeper
@@ -156,8 +156,8 @@ objects:
           image: ${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
-          - containerPort: 9092
-            name: kafka
+          - name: kafka
+            containerPort: 9092
             protocol: TCP
           env:
           - name: KAFKA_DEFAULT_REPLICATION_FACTOR
@@ -217,14 +217,14 @@ objects:
           image: ${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}
           imagePullPolicy: Always
           ports:
-          - containerPort: 2181
-            name: clientport
+          - name: clientport
+            containerPort: 2181
             protocol: TCP
-          - containerPort: 2888
-            name: clustering
+          - name: clustering
+            containerPort: 2888
             protocol: TCP
-          - containerPort: 3888
-            name: leaderelection
+          - name: leaderelection
+            containerPort: 3888
             protocol: TCP
           env:
           - name: ZOOKEEPER_NODE_COUNT

--- a/kafka-statefulsets/resources/zookeeper-headless-service.yaml
+++ b/kafka-statefulsets/resources/zookeeper-headless-service.yaml
@@ -4,17 +4,17 @@ metadata:
   name: zookeeper-headless
 spec:
   ports:
-    - port: 2181
-      name: clientport
-      targetPort : 2181
+    - name: clientport
+      port: 2181
+      targetPort: 2181
       protocol: TCP
-    - port: 2888
-      name: clustering
-      targetPort : 2888
+    - name: clustering
+      port: 2888
+      targetPort: 2888
       protocol: TCP
-    - port: 3888
-      name: leaderelection
-      targetPort : 3888
+    - name: leaderelection
+      port: 3888
+      targetPort: 3888
       protocol: TCP
   selector:
     name: zookeeper

--- a/kafka-statefulsets/resources/zookeeper-service.yaml
+++ b/kafka-statefulsets/resources/zookeeper-service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zookeeper
 spec:
   ports:
-    - port: 2181
-      name: clientport
-      targetPort : 2181
+    - name: clientport
+      port: 2181
+      targetPort: 2181
       protocol: TCP
   selector:
     name: zookeeper

--- a/kafka-statefulsets/resources/zookeeper.yaml
+++ b/kafka-statefulsets/resources/zookeeper.yaml
@@ -26,11 +26,11 @@ spec:
             - name: clientport
               containerPort: 2181
               protocol: TCP
-            - containerPort: 2888
-              name: clustering
+            - name: clustering
+              containerPort: 2888
               protocol: TCP
-            - containerPort: 3888
-              name: leaderelection
+            - name: leaderelection
+              containerPort: 3888
               protocol: TCP
           env:
             - name: ZOOKEEPER_NODE_COUNT


### PR DESCRIPTION
Fix port formatting in services and pods