### PR TITLE
Improve description in OpenShift templates

### DIFF
--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -2,6 +2,15 @@ apiVersion: v1
 kind: Template
 metadata:
   name: barnabas-connect
+  annotations:
+    openshift.io/display-name: "Apache Kafka Connect"
+    description: >-
+      This template installes Apache Kafka Connect in distributed mode. For more information
+      about using this template see https://github.com/EnMasseProject/barnabas
+    tags: "messaging"
+    iconClass: "fa pficon-topology"
+    template.openshift.io/documentation-url: "https://github.com/EnMasseProject/barnabas"
+message: "Use 'kafka-connect:8083' to access Kafka Connect REST API."
 parameters:
 - description: Specifies the number of Kafka Connect instances to be started by default.
   displayName: Number of Kafka connect instances

--- a/kafka-connect/s2i/resources/openshift-template.yaml
+++ b/kafka-connect/s2i/resources/openshift-template.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 kind: Template
 metadata:
   name: barnabas-connect-s2i
+  annotations:
+    openshift.io/display-name: "Apache Kafka Connect (with S2I build pipeline)"
+    description: >-
+      This template installes Apache Kafka Connect in distributed mode together with build pipeline
+      for new Kafka Connect images with additional plugins. For more information about using this 
+      template see https://github.com/EnMasseProject/barnabas
+    tags: "messaging"
+    iconClass: "fa pficon-topology"
+    template.openshift.io/documentation-url: "https://github.com/EnMasseProject/barnabas"
+message: "Use 'kafka-connect:8083' to access Kafka Connect REST API."
 parameters:
 - description: Specifies the number of Kafka Connect instances to be started by default.
   displayName: Number of Kafka connect instances

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -2,6 +2,19 @@ apiVersion: v1
 kind: Template
 metadata:
   name: barnabas
+  annotations:
+    openshift.io/display-name: "Apache Kafka (Ephemeral storage)"
+    description: >-
+      This template installes Apache Zookeeper and Apache Kafka clusters. For more information
+      about using this template see https://github.com/EnMasseProject/barnabas
+
+
+      WARNING: Any data stored will be lost upon pod destruction. Only use this
+      template for testing."
+    tags: "messaging,datastore"
+    iconClass: "fa pficon-topology"
+    template.openshift.io/documentation-url: "https://github.com/EnMasseProject/barnabas"
+message: "Use 'kafka:9092' as bootstrap server in your application"
 parameters:
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)

--- a/kafka-statefulsets/resources/openshift-template.yaml
+++ b/kafka-statefulsets/resources/openshift-template.yaml
@@ -2,6 +2,15 @@ apiVersion: v1
 kind: Template
 metadata:
   name: barnabas
+  annotations:
+    openshift.io/display-name: "Apache Kafka (Persistent storage)"
+    description: >-
+      This template installes Apache Zookeeper and Apache Kafka clusters. For more information
+      about using this template see https://github.com/EnMasseProject/barnabas
+    tags: "messaging,datastore"
+    iconClass: "fa pficon-topology"
+    template.openshift.io/documentation-url: "https://github.com/EnMasseProject/barnabas"
+message: "Use 'kafka:9092' as bootstrap server in your application"
 parameters:
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)


### PR DESCRIPTION
This PR improves the way the templates are displayed in the OpenShift catalog:
* Add Apache icon (no Kafka icon available)
* Add description of what the templates do
* Add link to Barnabas repo
* Categorize the tamples
   * Kafka goes into *Messaging* and *Data stores*
   * Kafka Connect goes into *Messaging*