### PR TITLE
Set log levels from env vars

### DIFF
--- a/kafka-base/config/log4j.properties
+++ b/kafka-base/config/log4j.properties
@@ -16,9 +16,9 @@
 # Unspecified loggers and loggers with additivity=true output to server.log and stdout
 # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
 
-kafka.root.logger=INFO, CONSOLE
+kafka.root.logger.level=INFO
 
-log4j.rootLogger=${kafka.root.logger}
+log4j.rootLogger=${kafka.root.logger.level}, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout

--- a/kafka-base/config/log4j.properties
+++ b/kafka-base/config/log4j.properties
@@ -15,7 +15,10 @@
 
 # Unspecified loggers and loggers with additivity=true output to server.log and stdout
 # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
-log4j.rootLogger=INFO, CONSOLE
+
+kafka.root.logger=INFO, CONSOLE
+
+log4j.rootLogger=${kafka.root.logger}
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
@@ -31,7 +34,7 @@ log4j.logger.org.apache.kafka=INFO
 
 ## The following loggers would log to kafka-request.log
 # Change to DEBUG or TRACE to enable request logging
-log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.logger.kafka.request.logger=WARN, CONSOLE
 # Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
 # related to the handling of requests
 #log4j.logger.kafka.network.Processor=TRACE

--- a/kafka-connect/config/connect-log4j.properties
+++ b/kafka-connect/config/connect-log4j.properties
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-connect.root.logger=INFO, CONSOLE
+connect.root.logger.level=INFO
 
-log4j.rootLogger=${connect.root.logger}
+log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender

--- a/kafka-connect/config/connect-log4j.properties
+++ b/kafka-connect/config/connect-log4j.properties
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, CONSOLE
+connect.root.logger=INFO, CONSOLE
+
+log4j.rootLogger=${connect.root.logger}
 
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender

--- a/kafka-connect/scripts/kafka_connect_run.sh
+++ b/kafka-connect/scripts/kafka_connect_run.sh
@@ -70,6 +70,14 @@ EOF
   # ... but enable equivalent GC logging to stdout
   export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
 
+  if [ -z "$KAFKA_LOG4J_OPTS" ]; then
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/connect-log4j.properties -Dconnect.root.logger=INFO,CONSOLE"
+  fi
+
+  # We don't need LOG_DIR because we write no log files, but setting it to a
+  # directory avoids trying to create it (and logging a permission denied error)
+  export LOG_DIR="$KAFKA_HOME"
+
   # starting Kafka server with final configuration
   exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/barnabas-connect.properties
 fi

--- a/kafka-connect/scripts/kafka_connect_run.sh
+++ b/kafka-connect/scripts/kafka_connect_run.sh
@@ -70,8 +70,11 @@ EOF
   # ... but enable equivalent GC logging to stdout
   export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
 
+  if [ -z "$KAFKA_CONNECT_LOG_LEVEL" ]; then
+    KAFKA_CONNECT_LOG_LEVEL="INFO"
+  fi
   if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/connect-log4j.properties -Dconnect.root.logger=INFO,CONSOLE"
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/connect-log4j.properties -Dconnect.root.logger.level=$KAFKA_CONNECT_LOG_LEVEL,CONSOLE"
   fi
 
   # We don't need LOG_DIR because we write no log files, but setting it to a

--- a/kafka-statefulsets/scripts/kafka_run.sh
+++ b/kafka-statefulsets/scripts/kafka_run.sh
@@ -18,8 +18,11 @@ export GC_LOG_ENABLED="false"
 # ... but enable equivalent GC logging to stdout
 export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
 
+if [ -z "$KAFKA_LOG_LEVEL" ]; then
+  KAFKA_LOG_LEVEL="INFO"
+fi
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then
-  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties -Dkafka.root.logger=INFO,CONSOLE"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties -Dkafka.root.logger.level=$KAFKA_LOG_LEVEL,CONSOLE"
 fi
 
 # We don't need LOG_DIR because we write no log files, but setting it to a

--- a/kafka-statefulsets/scripts/kafka_run.sh
+++ b/kafka-statefulsets/scripts/kafka_run.sh
@@ -2,7 +2,7 @@
 
 # volume for saving Kafka server logs
 export KAFKA_VOLUME="/var/lib/kafka/"
-# base name for Kafka server data dir and application logs
+# base name for Kafka server data dir
 export KAFKA_LOG_BASE_NAME="kafka-log"
 export KAFKA_APP_LOGS_BASE_NAME="logs"
 
@@ -17,6 +17,14 @@ echo "KAFKA_LOG_DIRS=$KAFKA_LOG_DIRS"
 export GC_LOG_ENABLED="false"
 # ... but enable equivalent GC logging to stdout
 export KAFKA_GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps"
+
+if [ -z "$KAFKA_LOG4J_OPTS" ]; then
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/config/log4j.properties -Dkafka.root.logger=INFO,CONSOLE"
+fi
+
+# We don't need LOG_DIR because we write no log files, but setting it to a
+# directory avoids trying to create it (and logging a permission denied error)
+export LOG_DIR="$KAFKA_HOME"
 
 # starting Kafka server with final configuration
 exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties \

--- a/zookeeper/config/log4j.properties
+++ b/zookeeper/config/log4j.properties
@@ -1,6 +1,6 @@
-zookeeper.root.logger=DEBUG, CONSOLE
+zookeeper.root.logger=DEBUG
 
-log4j.rootLogger=${zookeeper.root.logger}
+log4j.rootLogger=${zookeeper.root.logger}, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout

--- a/zookeeper/config/log4j.properties
+++ b/zookeeper/config/log4j.properties
@@ -1,4 +1,6 @@
-log4j.rootLogger=DEBUG, CONSOLE
+zookeeper.root.logger=DEBUG, CONSOLE
+
+log4j.rootLogger=${zookeeper.root.logger}
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout

--- a/zookeeper/scripts/zookeeper_run.sh
+++ b/zookeeper/scripts/zookeeper_run.sh
@@ -54,5 +54,9 @@ echo "Starting Zookeeper with configuration:"
 cat /tmp/zookeeper.properties
 echo ""
 
+if [ -z "$ZOO_LOG4J_PROP" ]; then
+  export ZOO_LOG4J_PROP="DEBUG, CONSOLE"
+fi
+
 # starting Zookeeper with final configuration
 exec $ZOOKEEPER_HOME/bin/zkServer.sh start-foreground /tmp/zookeeper.properties

--- a/zookeeper/scripts/zookeeper_run.sh
+++ b/zookeeper/scripts/zookeeper_run.sh
@@ -54,8 +54,11 @@ echo "Starting Zookeeper with configuration:"
 cat /tmp/zookeeper.properties
 echo ""
 
+if [ -z "$ZOOKEEPER_LOG_LEVEL" ]; then
+  ZOOKEEPER_LOG_LEVEL="DEBUG"
+fi
 if [ -z "$ZOO_LOG4J_PROP" ]; then
-  export ZOO_LOG4J_PROP="DEBUG, CONSOLE"
+  export ZOO_LOG4J_PROP="$ZOOKEEPER_LOG_LEVEL,CONSOLE"
 fi
 
 # starting Zookeeper with final configuration


### PR DESCRIPTION
Also set LOG_DIR because if we don't kafka-run-class.sh will try to create
a directory (which won't be used) only to get a permission denied error.

Fixes #91