### PR TITLE
Creating Prometheus config directory at Docker build image time

### DIFF
--- a/kafka-base/Dockerfile
+++ b/kafka-base/Dockerfile
@@ -34,6 +34,7 @@ RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_java
     && echo $JMX_EXPORTER_CHECKSUM > jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar.sha1 \
     && sha1sum --check jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar.sha1 \
     && mkdir /opt/prometheus \
+    && mkdir /opt/prometheus/config \
     && mv jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar /opt/prometheus/jmx_prometheus_javaagent.jar \
     && rm -rf jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.*
 

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -33,6 +33,7 @@ RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_java
     && echo $JMX_EXPORTER_CHECKSUM > jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar.sha1 \
     && sha1sum --check jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar.sha1 \
     && mkdir /opt/prometheus \
+    && mkdir /opt/prometheus/config \
     && mv jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.jar /opt/prometheus/jmx_prometheus_javaagent.jar \
     && rm -rf jmx_prometheus_javaagent-$JMX_EXPORTER_VERSION.*
 


### PR DESCRIPTION
It seems that there is a different behaviour between Kubernetes and OpenShift on mounting a ConfigMap as a volume which is a subdirectory of an already existing directory.
In this case we already have `/opt/prometheus` containing the JMX exporter jar file and we mount `config.yml` in the `config` subsdirectory.
While OpenShift leave the parent folder containing the jar file and adding the new subdirectory as mounted volume, Kubernetes just mount the entire volume "overriding" the directory so that the jar file disappear.
This PR creates the `config` directory upfront during the Docker build image time.