### PR TITLE
ScaleUp and ScaleDown are separate operations. They should not mark resources as different.

### DIFF
--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ResourceDiffResult.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ResourceDiffResult.java
@@ -48,7 +48,6 @@ public class ResourceDiffResult {
     }
 
     public void setScaleUp(Boolean scaleUp) {
-        setDifferent(true);
         this.scaleUp = scaleUp;
     }
 
@@ -57,7 +56,6 @@ public class ResourceDiffResult {
     }
 
     public void setScaleDown(Boolean scaleDown) {
-        setDifferent(true);
         this.scaleDown = scaleDown;
     }
 }


### PR DESCRIPTION
The current behavior results in unnecessary rolling update of Kafka Connect deployments. The `diff()` method in the resource class should decide whether scaling needs also patching or not. In similar way it is also implemented in Zookeeper which triggers rolling update when scaling (because cluster spec is part of ZK configuration)