### PR TITLE
Add try catch block to avoid null pointer exceptions ...

### DIFF
--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/cluster/UpdateKafkaConnectClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/cluster/UpdateKafkaConnectClusterOperation.java
@@ -34,8 +34,17 @@ public class UpdateKafkaConnectClusterOperation extends KafkaConnectClusterOpera
 
                 log.info("Updating Kafka Connect cluster {} in namespace {}", name, namespace);
 
-                KafkaConnectResource connect = KafkaConnectResource.fromConfigMap(k8s.getConfigmap(namespace, name));
-                ResourceDiffResult diff = connect.diff(k8s.getDeployment(namespace, name));
+                ResourceDiffResult diff;
+                KafkaConnectResource connect;
+                try {
+                    connect = KafkaConnectResource.fromConfigMap(k8s.getConfigmap(namespace, name));
+                    diff = connect.diff(k8s.getDeployment(namespace, name));
+                } catch (Exception e) {
+                    log.error("Caught exception while updating Kafka Connect cluster", e);
+                    handler.handle(Future.failedFuture(e));
+                    lock.release();
+                    return;
+                }
 
                 Future<Void> chainFuture = Future.future();
 

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/cluster/UpdateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/cluster/UpdateZookeeperClusterOperation.java
@@ -32,8 +32,17 @@ public class UpdateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
                 log.info("Updating Zookeeper cluster {} in namespace {}", name + "-zookeeper", namespace);
 
-                ZookeeperResource zk = ZookeeperResource.fromConfigMap(k8s.getConfigmap(namespace, name));
-                ResourceDiffResult diff = zk.diff(k8s.getStatefulSet(namespace, name + "-zookeeper"));
+                ResourceDiffResult diff;
+                ZookeeperResource zk;
+                try {
+                    zk = ZookeeperResource.fromConfigMap(k8s.getConfigmap(namespace, name));
+                    diff = zk.diff(k8s.getStatefulSet(namespace, name + "-zookeeper"));
+                } catch (Exception e) {
+                    log.error("Caught exception while updating Zookeeper cluster", e);
+                    handler.handle(Future.failedFuture(e));
+                    lock.release();
+                    return;
+                }
 
                 Future<Void> chainFuture = Future.future();
 


### PR DESCRIPTION
... when ConfigMap is already deleted which might result into the lock being not released. This might not be the best solution for long term, but it should help to avoid cluster deadlocks.