### PR TITLE
Add RBAC support to be able to run controller inside of K8s / OS

### DIFF
--- a/kafka-connect/resources/kubernetes.yaml
+++ b/kafka-connect/resources/kubernetes.yaml
@@ -7,11 +7,11 @@ metadata:
     type: deployment
     kind: kafka-connect
 data:
-  nodes: "3"
+  nodes: "1"
   image: "enmasseproject/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "my-kafka:9092"
+  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
   KAFKA_CONNECT_GROUP_ID: "my-connect-cluster"
   KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
   KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"

--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -77,6 +77,7 @@ parameters:
   displayName: Kafka Connect healthcheck timeout
   name: HEALTHCHECK_TIMEOUT
   value: "5"
+objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:

--- a/kafka-inmemory/resources/kubernetes.yaml
+++ b/kafka-inmemory/resources/kubernetes.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: barnabas
 ---
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
 metadata:
   name: barnabas-cluster-controller-role
   labels:
@@ -72,8 +72,8 @@ rules:
   - patch
   - update
 ---
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
 metadata:
   name: barnabas-cluster-controller-binding
   labels:

--- a/kafka-inmemory/resources/kubernetes.yaml
+++ b/kafka-inmemory/resources/kubernetes.yaml
@@ -1,3 +1,91 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: barnabas-cluster-controller
+  labels:
+    app: barnabas
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: barnabas-cluster-controller-role
+  labels:
+    app: barnabas
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: barnabas-cluster-controller-binding
+  labels:
+    app: barnabas
+subjects:
+  - kind: ServiceAccount
+    name: barnabas-cluster-controller
+roleRef:
+  kind: Role
+  name: barnabas-cluster-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -9,9 +97,11 @@ spec:
       labels:
         name: barnabas-cluster-controller
     spec:
+      serviceAccountName: barnabas-cluster-controller
       containers:
         - name: barnabas-cluster-controller
-          image: scholzj/barnabas-cluster-controller:latest
+          image: enmasseproject/barnabas-cluster-controller:latest
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,7 +115,7 @@ data:
   kafka-image: "enmasseproject/kafka-statefulsets:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
-  zookeeper-nodes: "3"
+  zookeeper-nodes: "1"
   zookeeper-image: "enmasseproject/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: barnabas
 ---
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
 metadata:
   name: barnabas-cluster-controller-role
   labels:
@@ -72,8 +72,8 @@ rules:
   - patch
   - update
 ---
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
 metadata:
   name: barnabas-cluster-controller-binding
   labels:

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: barnabas
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
+apiVersion: v1
+kind: ClusterRole
 metadata:
   name: barnabas-cluster-controller-role
   labels:
@@ -72,7 +72,7 @@ rules:
   - patch
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: v1
 kind: RoleBinding
 metadata:
   name: barnabas-cluster-controller-binding
@@ -82,9 +82,9 @@ subjects:
   - kind: ServiceAccount
     name: barnabas-cluster-controller
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: barnabas-cluster-controller-role
-  apiGroup: rbac.authorization.k8s.io
+  apiGroup: v1
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -1,3 +1,107 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: barnabas-cluster-controller
+  labels:
+    app: barnabas
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: barnabas-cluster-controller-role
+  labels:
+    app: barnabas
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: barnabas-cluster-controller-binding
+  labels:
+    app: barnabas
+subjects:
+  - kind: ServiceAccount
+    name: barnabas-cluster-controller
+roleRef:
+  kind: Role
+  name: barnabas-cluster-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: barnabas-cluster-controller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: barnabas-cluster-controller
+    spec:
+      serviceAccountName: barnabas-cluster-controller
+      containers:
+        - name: barnabas-cluster-controller
+          image: enmasseproject/barnabas-cluster-controller:latest
+---
 apiVersion: v1
 kind: Template
 metadata:
@@ -83,20 +187,6 @@ parameters:
   name: ZOOKEEPER_METRICS_ENABLED
   value: "true"
 objects:
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    name: barnabas-cluster-controller
-  spec:
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          name: barnabas-cluster-controller
-      spec:
-        containers:
-          - name: barnabas-cluster-controller
-            image: scholzj/barnabas-cluster-controller:latest
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -107,8 +197,8 @@ objects:
       kind: kafka
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
-    kafka-image: "${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:{KAFKA_IMAGE_TAG}"
-    kafka-healthcheck-delay: "{KAFKA_HEALTHCHECK_DELAY}"
+    kafka-image: "${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}"
+    kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
     zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
     zookeeper-image: "${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}"


### PR DESCRIPTION
This adds the initial RBAC support which allows to run cluster controller inside Kubernetes / Openshift. On  OpenShift, the controller is deployed immediately, the config maps only as resources from the catalog. The Kafka Connect always contains only a config map. The controller is expected to be deployed already with Kafka.