### PR TITLE
Cluster controller metrics

### DIFF
--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/K8SUtils.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/K8SUtils.java
@@ -110,7 +110,11 @@ public class K8SUtils {
     }
 
     public ConfigMap getConfigmap(String namespace, String name) {
-        return client.configMaps().inNamespace(namespace).withName(name).get();
+        return getConfigmapResource(namespace, name).get();
+    }
+
+    public Resource<ConfigMap, DoneableConfigMap> getConfigmapResource(String namespace, String name) {
+        return client.configMaps().inNamespace(namespace).withName(name);
     }
 
     public List<ConfigMap> getConfigmaps(String namespace, Map<String, String> labels) {
@@ -145,6 +149,13 @@ public class K8SUtils {
         if (podExists(namespace, name)) {
             log.debug("Deleting pod {}", name);
             getPodResource(namespace, name).delete();
+        }
+    }
+
+    public void deleteConfigMap(String namespace, String name) {
+        if (configMapExists(namespace, name)) {
+            log.debug("Deleting configmap {}", name);
+            getConfigmapResource(namespace, name).delete();
         }
     }
 

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/K8SUtils.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/K8SUtils.java
@@ -61,6 +61,11 @@ public class K8SUtils {
         client.extensions().deployments().createOrReplace(dep);
     }
 
+    public void createConfigMap(ConfigMap cm) {
+        log.info("Creating configmap {}", cm.getMetadata().getName());
+        client.configMaps().createOrReplace(cm);
+    }
+
     /*
       GET methods
      */
@@ -182,6 +187,10 @@ public class K8SUtils {
 
     public boolean podExists(String namespace, String name) {
         return getPod(namespace, name) == null ? false : true;
+    }
+
+    public boolean configMapExists(String namespace, String name) {
+        return getConfigmap(namespace, name) == null ? false : true;
     }
 
     /*

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/CreateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/CreateKafkaClusterOperation.java
@@ -27,9 +27,14 @@ public class CreateKafkaClusterOperation extends KafkaClusterOperation {
 
                 KafkaCluster kafka = KafkaCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
 
-                // TODO : create configMap only if metrics are enabled
+                // start creating configMap operation only if metrics are enabled,
+                // otherwise the future is already complete (for the "join")
                 Future<Void> futureConfigMap = Future.future();
-                OperationExecutor.getInstance().execute(new CreateConfigMapOperation(kafka.generateMetricsConfigMap()), futureConfigMap.completer());
+                if (kafka.isMetricsEnabled()) {
+                    OperationExecutor.getInstance().execute(new CreateConfigMapOperation(kafka.generateMetricsConfigMap()), futureConfigMap.completer());
+                } else {
+                    futureConfigMap.complete();
+                }
 
                 Future<Void> futureService = Future.future();
                 OperationExecutor.getInstance().execute(new CreateServiceOperation(kafka.generateService()), futureService.completer());

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/CreateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/CreateZookeeperClusterOperation.java
@@ -27,9 +27,14 @@ public class CreateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
                 ZookeeperCluster zk = ZookeeperCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
 
-                // TODO : create configMap only if metrics are enabled
+                // start creating configMap operation only if metrics are enabled,
+                // otherwise the future is already complete (for the "join")
                 Future<Void> futureConfigMap = Future.future();
-                OperationExecutor.getInstance().execute(new CreateConfigMapOperation(zk.generateMetricsConfigMap()), futureConfigMap.completer());
+                if (zk.isMetricsEnabled()) {
+                    OperationExecutor.getInstance().execute(new CreateConfigMapOperation(zk.generateMetricsConfigMap()), futureConfigMap.completer());
+                } else {
+                    futureConfigMap.complete();
+                }
 
                 Future<Void> futureService = Future.future();
                 OperationExecutor.getInstance().execute(new CreateServiceOperation(zk.generateService()), futureService.completer());

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/DeleteKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/DeleteKafkaClusterOperation.java
@@ -1,6 +1,7 @@
 package io.enmasse.barnabas.controller.cluster.operations;
 
 import io.enmasse.barnabas.controller.cluster.K8SUtils;
+import io.enmasse.barnabas.controller.cluster.operations.kubernetes.DeleteConfigMapOperation;
 import io.enmasse.barnabas.controller.cluster.operations.kubernetes.DeleteServiceOperation;
 import io.enmasse.barnabas.controller.cluster.operations.kubernetes.DeleteStatefulSetOperation;
 import io.enmasse.barnabas.controller.cluster.resources.KafkaCluster;
@@ -26,6 +27,15 @@ public class DeleteKafkaClusterOperation extends KafkaClusterOperation {
 
                 KafkaCluster kafka = KafkaCluster.fromStatefulSet(k8s.getStatefulSet(namespace, name));
 
+                // start deleting configMap operation only if metrics are enabled,
+                // otherwise the future is already complete (for the "join")
+                Future<Void> futureConfigMap = Future.future();
+                if (kafka.isMetricsEnabled()) {
+                    OperationExecutor.getInstance().execute(new DeleteConfigMapOperation(namespace, kafka.getMetricsConfigName()), futureConfigMap.completer());
+                } else {
+                    futureConfigMap.complete();
+                }
+
                 Future<Void> futureService = Future.future();
                 OperationExecutor.getInstance().execute(new DeleteServiceOperation(namespace, name), futureService.completer());
 
@@ -35,7 +45,7 @@ public class DeleteKafkaClusterOperation extends KafkaClusterOperation {
                 Future<Void> futureStatefulSet = Future.future();
                 OperationExecutor.getInstance().execute(new DeleteStatefulSetOperation(namespace, name), futureStatefulSet.completer());
 
-                CompositeFuture.join(futureService, futureHeadlessService, futureStatefulSet).setHandler(ar -> {
+                CompositeFuture.join(futureConfigMap, futureService, futureHeadlessService, futureStatefulSet).setHandler(ar -> {
                     if (ar.succeeded()) {
                         log.info("Kafka cluster {} successfully deleted from namespace {}", name, namespace);
                         handler.handle(Future.succeededFuture());

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateKafkaClusterOperation.java
@@ -130,12 +130,9 @@ public class UpdateKafkaClusterOperation extends KafkaClusterOperation {
 
     private Future<Void> patchMetricsConfigMap(KafkaCluster kafka, ClusterDiffResult diff) {
         if (diff.isMetricsChanged()) {
-            if (kafka.isMetricsEnabled()) {
-                Future<Void> patchConfigMap = Future.future();
-                OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, kafka.getMetricsConfigName()), kafka.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-metrics-config"))), patchConfigMap.completer());
-                return patchConfigMap;
-            } else
-                return Future.succeededFuture();
+            Future<Void> patchConfigMap = Future.future();
+            OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, kafka.getMetricsConfigName()), kafka.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-metrics-config"))), patchConfigMap.completer());
+            return patchConfigMap;
         } else {
             return Future.succeededFuture();
         }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateKafkaClusterOperation.java
@@ -129,10 +129,13 @@ public class UpdateKafkaClusterOperation extends KafkaClusterOperation {
     }
 
     private Future<Void> patchMetricsConfigMap(KafkaCluster kafka, ClusterDiffResult diff) {
-        if (diff.getDifferent()) {
-            Future<Void> patchConfigMap = Future.future();
-            OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, kafka.getMetricsConfigName()), kafka.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-metrics-config"))), patchConfigMap.completer());
-            return patchConfigMap;
+        if (diff.isMetricsChanged()) {
+            if (kafka.isMetricsEnabled()) {
+                Future<Void> patchConfigMap = Future.future();
+                OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, kafka.getMetricsConfigName()), kafka.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-metrics-config"))), patchConfigMap.completer());
+                return patchConfigMap;
+            } else
+                return Future.succeededFuture();
         } else {
             return Future.succeededFuture();
         }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateZookeeperClusterOperation.java
@@ -127,13 +127,9 @@ public class UpdateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
     private Future<Void> patchMetricsConfigMap(ZookeeperCluster zk, ClusterDiffResult diff) {
         if (diff.isMetricsChanged()) {
-
-            if (zk.isMetricsEnabled()) {
-                Future<Void> patchConfigMap = Future.future();
-                OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, zk.getMetricsConfigName()), zk.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-zookeeper-metrics-config"))), patchConfigMap.completer());
-                return patchConfigMap;
-            } else
-                return Future.succeededFuture();
+            Future<Void> patchConfigMap = Future.future();
+            OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, zk.getMetricsConfigName()), zk.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-zookeeper-metrics-config"))), patchConfigMap.completer());
+            return patchConfigMap;
         } else {
             return Future.succeededFuture();
         }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/UpdateZookeeperClusterOperation.java
@@ -126,9 +126,10 @@ public class UpdateZookeeperClusterOperation extends ZookeeperClusterOperation {
     }
 
     private Future<Void> patchMetricsConfigMap(ZookeeperCluster zk, ClusterDiffResult diff) {
-        if (diff.getDifferent()) {
-            Future<Void> patchConfigMap = Future.future();
+        if (diff.isMetricsChanged()) {
+
             if (zk.isMetricsEnabled()) {
+                Future<Void> patchConfigMap = Future.future();
                 OperationExecutor.getInstance().execute(new PatchOperation(k8s.getConfigmapResource(namespace, zk.getMetricsConfigName()), zk.patchMetricsConfigMap(k8s.getConfigmap(namespace, name + "-zookeeper-metrics-config"))), patchConfigMap.completer());
                 return patchConfigMap;
             } else

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/kubernetes/CreateConfigMapOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/kubernetes/CreateConfigMapOperation.java
@@ -1,0 +1,52 @@
+package io.enmasse.barnabas.controller.cluster.operations.kubernetes;
+
+import io.enmasse.barnabas.controller.cluster.K8SUtils;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateConfigMapOperation extends K8sOperation {
+
+    private static final Logger log = LoggerFactory.getLogger(CreateConfigMapOperation.class.getName());
+    private final ConfigMap cm;
+
+    public CreateConfigMapOperation(ConfigMap cm) {
+        this.cm = cm;
+    }
+
+    @Override
+    public void execute(Vertx vertx, K8SUtils k8s, Handler<AsyncResult<Void>> handler) {
+        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+                future -> {
+                    if (!k8s.configMapExists(cm.getMetadata().getNamespace(), cm.getMetadata().getName())) {
+                        try {
+                            log.info("Creating configmap {}", cm);
+                            k8s.createConfigMap(cm);
+                            future.complete();
+                        } catch (Exception e) {
+                            log.error("Caught exception while creating configmap", e);
+                            future.fail(e);
+                        }
+                    }
+                    else {
+                        log.warn("Configmap {} already exists", cm);
+                        future.complete();
+                    }
+                }, false,
+                res -> {
+                    if (res.succeeded()) {
+                        log.info("Configmap {} has been created", cm);
+                        handler.handle(Future.succeededFuture());
+                    }
+                    else {
+                        log.error("Configmap creation failed: {}", res.result());
+                        handler.handle(Future.failedFuture((Exception)res.result()));
+                    }
+                }
+        );
+    }
+}

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/kubernetes/DeleteConfigMapOperation.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/operations/kubernetes/DeleteConfigMapOperation.java
@@ -1,0 +1,52 @@
+package io.enmasse.barnabas.controller.cluster.operations.kubernetes;
+
+import io.enmasse.barnabas.controller.cluster.K8SUtils;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteConfigMapOperation extends K8sOperation {
+
+    private static final Logger log = LoggerFactory.getLogger(DeleteConfigMapOperation.class.getName());
+    private final String namespace;
+    private final String name;
+
+    public DeleteConfigMapOperation(String namespace, String name) {
+        this.namespace = namespace;
+        this.name = name;
+    }
+
+    @Override
+    public void execute(Vertx vertx, K8SUtils k8s, Handler<AsyncResult<Void>> handler) {
+        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+                future -> {
+                    if (k8s.configMapExists(namespace, name)) {
+                        try {
+                            log.info("Deleting configmap {} in namespace {}", name, namespace);
+                            k8s.deleteConfigMap(namespace, name);
+                            future.complete();
+                        } catch (Exception e) {
+                            log.error("Caught exception while deleting configmap", e);
+                            future.fail(e);
+                        }
+                    } else {
+                        log.warn("Configmap {} in namespace {} doesn't exists", name, namespace);
+                        future.complete();
+                    }
+                }, false,
+                res -> {
+                    if (res.succeeded()) {
+                        log.info("Configmap {} in namespace {} has been deleted", name, namespace);
+                        handler.handle(Future.succeededFuture());
+                    }
+                    else {
+                        log.error("Configmap deletion failed: {}", res.result());
+                        handler.handle(Future.failedFuture((Exception)res.result()));
+                    }
+                }
+        );
+    }
+}

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
@@ -40,6 +40,7 @@ public abstract class AbstractCluster {
     protected boolean isMetricsEnabled;
 
     protected JsonObject metricsConfig;
+    protected String metricsConfigName;
 
     protected AbstractCluster(String namespace, String name) {
         this.name = name;
@@ -105,6 +106,14 @@ public abstract class AbstractCluster {
         this.metricsConfig = metricsConfig;
     }
 
+    public String getMetricsConfigName() {
+        return metricsConfigName;
+    }
+
+    protected void setMetricsConfigName(String metricsConfigName) {
+        this.metricsConfigName = metricsConfigName;
+    }
+
     protected List<EnvVar> getEnvVars() {
         return null;
     }
@@ -149,10 +158,10 @@ public abstract class AbstractCluster {
         return volume;
     }
 
-    protected Volume createConfigMapVolume(String name) {
+    protected Volume createConfigMapVolume(String name, String configMapName) {
 
         ConfigMapVolumeSource configMapVolumeSource = new ConfigMapVolumeSourceBuilder()
-                .withName(name)
+                .withName(configMapName)
                 .build();
 
         Volume volume = new VolumeBuilder()

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
@@ -89,7 +89,7 @@ public abstract class AbstractCluster {
         return labelsWithName;
     }
 
-    protected boolean isMetricsEnabled() {
+    public boolean isMetricsEnabled() {
         return isMetricsEnabled;
     }
 

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
@@ -174,7 +174,7 @@ public abstract class AbstractCluster {
 
     protected ConfigMap createConfigMap(String name, Map<String, String> data) {
 
-        ConfigMap metricsCm = new ConfigMapBuilder()
+        ConfigMap cm = new ConfigMapBuilder()
                 .withNewMetadata()
                 .withName(name)
                 .withNamespace(namespace)
@@ -182,7 +182,7 @@ public abstract class AbstractCluster {
                 .withData(data)
                 .build();
 
-        return metricsCm;
+        return cm;
     }
 
     protected Probe createExecProbe(String command, int initialDelay, int timeout) {

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/AbstractCluster.java
@@ -367,4 +367,11 @@ public abstract class AbstractCluster {
 
         return dep;
     }
+
+    public ConfigMap patchConfigMap(ConfigMap cm, Map<String, String> data) {
+
+        cm.setData(data);
+
+        return cm;
+    }
 }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ClusterDiffResult.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ClusterDiffResult.java
@@ -5,6 +5,7 @@ public class ClusterDiffResult {
     private Boolean rollingUpdate = false;
     private Boolean scaleUp = false;
     private Boolean scaleDown = false;
+    private boolean isMetricsChanged = false;
 
     public ClusterDiffResult() {
         // Nothing to do
@@ -57,5 +58,13 @@ public class ClusterDiffResult {
 
     public void setScaleDown(Boolean scaleDown) {
         this.scaleDown = scaleDown;
+    }
+
+    public boolean isMetricsChanged() {
+        return isMetricsChanged;
+    }
+
+    public void setMetricsChanged(boolean metricsChanged) {
+        isMetricsChanged = metricsChanged;
     }
 }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/KafkaCluster.java
@@ -165,14 +165,14 @@ public class KafkaCluster extends AbstractCluster {
 
         if (isMetricsEnabled != Boolean.parseBoolean(vars.getOrDefault(KEY_KAFKA_METRICS_ENABLED, String.valueOf(DEFAULT_KAFKA_METRICS_ENABLED)))) {
             log.info("Diff: Kafka metrics enabled/disabled");
-            diff.setDifferent(true);
+            diff.setMetricsChanged(true);
             diff.setRollingUpdate(true);
         } else {
 
             if (isMetricsEnabled) {
                 JsonObject metricsConfig = new JsonObject(metricsConfigMap.getData().get("config.yml"));
                 if (!this.metricsConfig.equals(metricsConfig)) {
-                    diff.setDifferent(true);
+                    diff.setMetricsChanged(true);
                 }
             }
         }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/KafkaCluster.java
@@ -82,10 +82,10 @@ public class KafkaCluster extends AbstractCluster {
 
         // TODO : making more checks for exception on JSON ?
         String metricsConfig = cm.getData().get(KEY_METRICS_CONFIG);
+        kafka.setMetricsConfigName(cm.getMetadata().getName() + "-metrics-config");
         kafka.setMetricsEnabled(metricsConfig != null);
         if (kafka.isMetricsEnabled()) {
             kafka.setMetricsConfig(new JsonObject(metricsConfig));
-            kafka.setMetricsConfigName(cm.getMetadata().getName() + "-metrics-config");
         }
 
         return kafka;
@@ -219,7 +219,7 @@ public class KafkaCluster extends AbstractCluster {
     public ConfigMap patchMetricsConfigMap(ConfigMap cm) {
 
         Map<String, String> data = new HashMap<>();
-        data.put("config.yml", metricsConfig.toString());
+        data.put("config.yml", metricsConfig != null ? metricsConfig.toString() : null);
 
         return patchConfigMap(cm, data);
     }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ZookeeperCluster.java
@@ -74,10 +74,10 @@ public class ZookeeperCluster extends AbstractCluster {
 
         // TODO : making more checks for exception on JSON ?
         String metricsConfig = cm.getData().get(KEY_METRICS_CONFIG);
+        zk.setMetricsConfigName(cm.getMetadata().getName() + "-zookeeper-metrics-config");
         zk.setMetricsEnabled(metricsConfig != null);
         if (zk.isMetricsEnabled()) {
             zk.setMetricsConfig(new JsonObject(metricsConfig));
-            zk.setMetricsConfigName(cm.getMetadata().getName() + "-zookeeper-metrics-config");
         }
 
         return zk;
@@ -197,7 +197,7 @@ public class ZookeeperCluster extends AbstractCluster {
     public ConfigMap patchMetricsConfigMap(ConfigMap cm) {
 
         Map<String, String> data = new HashMap<>();
-        data.put("config.yml", metricsConfig.toString());
+        data.put("config.yml", metricsConfig != null ? metricsConfig.toString() : null);
 
         return patchConfigMap(cm, data);
     }

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/resources/ZookeeperCluster.java
@@ -144,14 +144,14 @@ public class ZookeeperCluster extends AbstractCluster {
 
         if (isMetricsEnabled != Boolean.parseBoolean(vars.getOrDefault(KEY_ZOOKEEPER_METRICS_ENABLED, String.valueOf(DEFAULT_ZOOKEEPER_METRICS_ENABLED)))) {
             log.info("Diff: Zookeeper metrics enabled/disabled");
-            diff.setDifferent(true);
+            diff.setMetricsChanged(true);
             diff.setRollingUpdate(true);
         } else {
 
             if (isMetricsEnabled) {
                 JsonObject metricsConfig = new JsonObject(metricsConfigMap.getData().get("config.yml"));
                 if (!this.metricsConfig.equals(metricsConfig)) {
-                    diff.setDifferent(true);
+                    diff.setMetricsChanged(true);
                 }
             }
         }


### PR DESCRIPTION
This PR adds creating ConfigMaps for metrics configuration from the cluster ConfigMap.
It handles deleting such CMs when the cluster is deleted and updating the metrics configuration in the pods when it's updated in the cluster ConfigMap.
There is a not covered case : when the metrics are completely disabled/enabled.
On disabling metrics, for example, we should remove the ConfigMap volume in the StatefulsSets other then removing the related volume mount and the metrics port. While doing the last two steps is possible using a "patching", it's not possible to remove the volume (you can change only replicas and containers specification of a Statefulsets but not other fields).
In order to remove the volume, the Statefulsets should be deleted but not the backed pods and then recreate it.
In this scenario, a rolling update should be needed as well, because we don't need the JMX exporter running as agent with the Kafka broker.
We have to discuss about that and if that idea could work. Wdyt @scholzj ?